### PR TITLE
fix: No payment modal on iOS 

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,9 @@
 
 If you are developing for IOS, ensure that the version of Xcode you are running is **10.0** (the latest version). Using a lower version causes the build to fail.
 
+Also, do not run ```cordova prepare ios```. 
+Rather, after adding the ```ios``` platform with ```cordova platform add ios```, simply navigate to the ```ios``` folder within the ```platforms``` directory and open the ```.xcworkspace``` file in ```xcode``` then build from there.
+
 ## Getting Started
 
 These instructions will get you up and running on your local machine for development and testing purposes. See Deployment section for notes on how to deploy the project on a live system.

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,11 @@
 
  ![e.g](https://cloud.githubusercontent.com/assets/5229321/21958475/be1763c2-daaf-11e6-8df0-75f2e4f0168e.gif)
 
+
+**UPDATE (FOR IOS)**
+
+If you are developing for IOS, ensure that the version of Xcode you are running is **10.0** (the latest version). Using a lower version causes the build to fail.
+
 ## Getting Started
 
 These instructions will get you up and running on your local machine for development and testing purposes. See Deployment section for notes on how to deploy the project on a live system.


### PR DESCRIPTION
Resolves NA 
Type: **feature|bugfix**
Replaces #38 

## Issue
Cordova user's could not run the SDK successfully on IOS, the instructions to run the SDK with IOS has been documented in the readme. 

## Solution
- IOS users need to run it in Xcode 10x.

## Breaking changes
- None.

## Testing
1. Follow the readme to test.